### PR TITLE
Adds multi OTP sending functionality

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -8,7 +8,7 @@ export declare const SMSStatus: {
     DeliveryUnknown: string;
     Error: string;
 };
-export declare type SMSStatus = (typeof SMSStatus)[keyof typeof SMSStatus];
+export type SMSStatus = (typeof SMSStatus)[keyof typeof SMSStatus];
 export declare const SMSSMSCStatus: {
     DeliverySuccess: string;
     DeliveryFailure: string;
@@ -16,8 +16,8 @@ export declare const SMSSMSCStatus: {
     SmscSubmit: string;
     SmscReject: string;
 };
-export declare type SMSSMSCStatus = (typeof SMSSMSCStatus)[keyof typeof SMSSMSCStatus];
-export declare type SMS = {
+export type SMSSMSCStatus = (typeof SMSSMSCStatus)[keyof typeof SMSSMSCStatus];
+export type SMS = {
     id: string;
     to: string;
     message: string;
@@ -30,16 +30,16 @@ export declare type SMS = {
     createdAt: Date;
     updatedAt: Date;
 };
-export declare type OTPResponse = {
+export type OTPResponse = {
     status: 0 | -1;
     otpToken: string;
 };
-export declare type VerifyOPTRequest = {
+export type VerifyOPTRequest = {
     identity: string;
     otp: string;
     verificationKey: string;
 };
-export declare type VerifyOPTResponse = {
+export type VerifyOPTResponse = {
     identity: string;
     otp: string;
     verificationKey: string;
@@ -55,13 +55,20 @@ export declare class Ikoddi {
     withGroupId(groupId: string): Ikoddi;
     withOtpAppId(otpAppId: string): Ikoddi;
     _assertAllParametersAreCorrect(): void;
-    sendAirtime(numbers: Array<string>, ref: string, amount: string, campaignName: string, phonecode?: string, isoCode?: string): Promise<any>;
+    sendAirtime(numbers: Array<string>, ref: string, amount: string, campaignName: string, phonecode?: string, isoCode?: string): Promise<import("axios").AxiosResponse<any, any>>;
     sendSMS(numbers: Array<string>, from: string, message: string, smsBroadCast: string, phonecode?: string, isoCode?: string): Promise<SMS[]>;
-    sendOTP(identity: string, type?: "sms" | "email", messageContext?: Record<string, any>): Promise<OTPResponse>;
+    sendOTP(identity: string, type?: "sms" | "email" | "whatsapp", messageContext?: Record<string, any>): Promise<OTPResponse>;
+    sendMultiOTP(data: {
+        identities: Array<{
+            identity: string;
+            channel: "SMS" | "EMAIL" | "WHATSAPP";
+        }>;
+        messageContext?: Record<string, any>;
+    }): Promise<OTPResponse>;
     verifyOTP(otpData: {
         verificationKey: string;
         otp: string;
         identity: string;
     }): Promise<OTPResponse>;
-    internetPlans(): Promise<any>;
+    internetPlans(): Promise<import("axios").AxiosResponse<any, any>>;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -11,6 +12,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Ikoddi = exports.SMSSMSCStatus = exports.SMSStatus = void 0;
 const axios_1 = __importDefault(require("axios"));
 exports.SMSStatus = {
     SendingOK: "SendingOK",
@@ -60,8 +62,8 @@ class Ikoddi {
             throw new Error("The group ID should be defined");
         }
     }
-    sendAirtime(numbers, ref, amount, campaignName, phonecode = "226", isoCode = "BF") {
-        return __awaiter(this, void 0, void 0, function* () {
+    sendAirtime(numbers_1, ref_1, amount_1, campaignName_1) {
+        return __awaiter(this, arguments, void 0, function* (numbers, ref, amount, campaignName, phonecode = "226", isoCode = "BF") {
             this._assertAllParametersAreCorrect();
             const data = {
                 sentTo: numbers,
@@ -85,8 +87,8 @@ class Ikoddi {
             }
         });
     }
-    sendSMS(numbers, from, message, smsBroadCast, phonecode = "226", isoCode = "BF") {
-        return __awaiter(this, void 0, void 0, function* () {
+    sendSMS(numbers_1, from_1, message_1, smsBroadCast_1) {
+        return __awaiter(this, arguments, void 0, function* (numbers, from, message, smsBroadCast, phonecode = "226", isoCode = "BF") {
             this._assertAllParametersAreCorrect();
             const data = {
                 sentTo: numbers,
@@ -110,14 +112,34 @@ class Ikoddi {
             }
         });
     }
-    sendOTP(identity, type = "sms", messageContext = {}) {
-        return __awaiter(this, void 0, void 0, function* () {
+    sendOTP(identity_1) {
+        return __awaiter(this, arguments, void 0, function* (identity, type = "sms", messageContext = {}) {
             this._assertAllParametersAreCorrect();
             if (this.otpAppId === null || this.otpAppId === undefined) {
                 throw new Error("OTP App ID should be defined");
             }
             try {
                 const otpResponse = yield axios_1.default.post(`${this.apiBaseURL}${this.groupId}/otp/${this.otpAppId}/${type}/${encodeURI(identity)}`, messageContext, {
+                    headers: {
+                        "Content-type": "application/json",
+                        "x-api-key": this.apiKey,
+                    },
+                });
+                return otpResponse.data;
+            }
+            catch (err) {
+                throw err;
+            }
+        });
+    }
+    sendMultiOTP(data) {
+        return __awaiter(this, void 0, void 0, function* () {
+            this._assertAllParametersAreCorrect();
+            if (this.otpAppId === null || this.otpAppId === undefined) {
+                throw new Error("OTP App ID should be defined");
+            }
+            try {
+                const otpResponse = yield axios_1.default.post(`${this.apiBaseURL}${this.groupId}/otp/${this.otpAppId}/send-multi`, data, {
                     headers: {
                         "Content-type": "application/json",
                         "x-api-key": this.apiKey,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
-  "name": "ikoddi-nodejs-sdk",
-  "version": "1.0.0",
+  "name": "ikoddi-client-sdk",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ikoddi-nodejs-sdk",
-      "version": "1.0.0",
+      "name": "ikoddi-client-sdk",
+      "version": "1.1.5",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.4.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/asynckit": {
@@ -101,6 +104,19 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ikoddi-client-sdk",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Ikoddi Airtime and Message (SMS, USSD) SDK. https://ikoddi.com",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,5 +20,8 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.4.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
Introduces the ability to send OTPs to multiple users via different channels in a single request.

Updates the `sendOTP` method to support an additional "whatsapp" type and adds a new `sendMultiOTP` method.